### PR TITLE
Fix `get_stat_per_host`

### DIFF
--- a/hoststats/results.py
+++ b/hoststats/results.py
@@ -58,7 +58,7 @@ class HostStatsResults:
         stats_per_host = dict()
         for host in hosts:
             host_ts = self.full_results["Host"] == host
-            stats_per_host[host] = host_ts[stat]
+            stats_per_host[host] = self.full_results.loc[host_ts][stat]
 
         return stats_per_host
 

--- a/hoststats/results.py
+++ b/hoststats/results.py
@@ -58,7 +58,9 @@ class HostStatsResults:
         stats_per_host = dict()
         for host in hosts:
             host_ts = self.full_results["Host"] == host
-            stats_per_host[host] = self.full_results.loc[host_ts][stat]
+            stats_per_host[host] = self.full_results.loc[host_ts][
+                ["Timestamp", stat]
+            ]
 
         return stats_per_host
 

--- a/hoststats/tests/test_results.py
+++ b/hoststats/tests/test_results.py
@@ -24,6 +24,9 @@ class TestHostStatsResults(TestCase):
         self.assertEqual(
             r.get_stats(), CPU_STATS + MEM_STATS + DISK_STATS + NET_STATS
         )
+        self.assertEqual(
+            len(r.get_stat_per_host("CPU_PCT").keys()), len(hosts)
+        )
 
         self.assertRaises(RuntimeError, r.get_stat_per_host, "blahblah")
         self.assertRaises(RuntimeError, r.get_median_stat, "blahblah")


### PR DESCRIPTION
Fix a small bug that was preventing the usage of the `get_stat_per_host` attribute in `HostStatsResults`. I also return the timestamp together with the stat as it is otherwise hard to plot the returned series.

Unfortunately, I think you must still bump the version and do the release cycle yourself.